### PR TITLE
 [BUGFIX] cpu.util指标计算异常

### DIFF
--- a/collect/kubelet_cadvisor.go
+++ b/collect/kubelet_cadvisor.go
@@ -231,6 +231,7 @@ func DoKubeletCollect(cg *config.Config, logger log.Logger, dataMap *HistoryMap,
 				newM := metric
 				newM.Metric = "cpu.cores.occupy"
 				metricList = append(metricList, newM)
+				continue
 			}
 
 		case "container_cpu_user_seconds_total":


### PR DESCRIPTION
这里未加continue，存储了cpu.util指标的异常数据，造成后面计算指标时结果不正确